### PR TITLE
Girls that are taken off work by the matron due to tiredness will now…

### DIFF
--- a/ crazys-wm-mod/cBrothel.cpp
+++ b/ crazys-wm-mod/cBrothel.cpp
@@ -2519,17 +2519,7 @@ bool is_she_cleaning(sGirl *girl)
 }
 bool is_she_resting(sGirl *girl)
 {
-	if ((girl->m_DayJob == JOB_FILMFREETIME	&& girl->m_NightJob == JOB_FILMFREETIME) ||
-		(girl->m_DayJob == JOB_ARENAREST	&& girl->m_NightJob == JOB_ARENAREST) ||
-		(girl->m_DayJob == JOB_CENTREREST	&& girl->m_NightJob == JOB_CENTREREST) ||
-		(girl->m_DayJob == JOB_CLINICREST	&& girl->m_NightJob == JOB_CLINICREST) ||
-		(girl->m_DayJob == JOB_HOUSEREST	&& girl->m_NightJob == JOB_HOUSEREST) ||
-		(girl->m_DayJob == JOB_FARMREST		&& girl->m_NightJob == JOB_FARMREST) ||
-		(girl->m_DayJob == JOB_RESTING		&& girl->m_NightJob == JOB_RESTING))
-	{
-		return true;
-	}
-	return false;
+	return girl->is_resting();
 }
 bool is_she_stripping(sGirl *girl)
 {

--- a/ crazys-wm-mod/cGirls.cpp
+++ b/ crazys-wm-mod/cGirls.cpp
@@ -2308,7 +2308,7 @@ string cGirls::GetMoreDetailsString(sGirl* girl, bool purchase)
 		ss << "\nCost per turn: " << ((girl->is_slave() ? 5 : 20) * (girl->m_AccLevel + 1)) << " gold.\n";
 
 		// added from Dagoth
-		if (girl->m_DayJob == JOB_RESTING && girl->m_NightJob == JOB_RESTING && girl->m_PrevDayJob != 255 && girl->m_PrevNightJob != 255)
+		if (girl->is_resting() && girl->m_PrevDayJob != 255 && girl->m_PrevNightJob != 255)
 		{
 			ss << "\n\nOFF WORK, RESTING DUE TO TIREDNESS.";
 			ss << "\nStored Day Job:   " << g_Brothels.m_JobManager.JobName[girl->m_PrevDayJob];
@@ -15634,6 +15634,10 @@ void sGirl::OutputGirlDetailString(string& Data, const string& detailName)
 		else if (g_Studios.is_Actress_Job(DN_Job) && g_Studios.CrewNeeded())
 		{
 			ss << g_Brothels.m_JobManager.JobName[DN_Job] << " **";
+		}
+		else if (is_resting() && m_PrevDayJob != 255 && m_PrevNightJob != 255)
+		{
+			ss << "[z] " << g_Brothels.m_JobManager.JobName[(DN_Day == 0 ? m_PrevDayJob : m_PrevNightJob)];
 		}
 		else
 		{

--- a/ crazys-wm-mod/cGirls.h
+++ b/ crazys-wm-mod/cGirls.h
@@ -781,6 +781,21 @@ struct sGirl
 	bool is_isdaughter()	{ return (m_States & (1 << STATUS_ISDAUGHTER)) != 0; }
 	bool is_warrior()		{ return !is_arena(); }
 
+	bool is_resting()
+	{
+		if ((m_DayJob == JOB_FILMFREETIME	&& m_NightJob == JOB_FILMFREETIME) ||
+			(m_DayJob == JOB_ARENAREST		&& m_NightJob == JOB_ARENAREST) ||
+			(m_DayJob == JOB_CENTREREST		&& m_NightJob == JOB_CENTREREST) ||
+			(m_DayJob == JOB_CLINICREST		&& m_NightJob == JOB_CLINICREST) ||
+			(m_DayJob == JOB_HOUSEREST		&& m_NightJob == JOB_HOUSEREST) ||
+			(m_DayJob == JOB_FARMREST		&& m_NightJob == JOB_FARMREST) ||
+			(m_DayJob == JOB_RESTING		&& m_NightJob == JOB_RESTING))
+		{
+			return true;
+		}
+		return false;
+	}
+
 	void fight_own_gang(bool &girl_wins);
 	void win_vs_own_gang(vector<sGang*> &v, int max_goons, bool &girl_wins);
 	void lose_vs_own_gang(vector<sGang*> &v, int max_goons, int girl_stats, int gang_stats, bool &girl_wins);


### PR DESCRIPTION
… have their jobs listed as "[z] " followed by the stored job title (example "[z] Security") in the Girl Management listbox, instead of just being listed as "Free Time". This way, it can be seen at a glance that she's just temporarily off work due to tiredness rather than just doing nothing, and you can see what job she will be going back to when the matron puts her back to work.
This doesn't affect the job selection listboxes, only the list of girls.

I moved code for cBrothel->is_she_resting(sGirl *girl) up to cGirls, so it's more widely accessible. For simplicity it's currently just redirecting calls for cBrothel->is_she_resting() to the new method, but it would probably be better to change all references to point to the new location in cGirl->is_resting() and remove the old one in cBrothel->is_she_resting().
