### PR TITLE
Linux fixes: image finding/sorting, rival inventories, warnings/errors

### DIFF
--- a/ crazys-wm-mod/FileList.cpp
+++ b/ crazys-wm-mod/FileList.cpp
@@ -96,7 +96,8 @@ void FileList::add(const char *pattern)
 	const char	*base_path = folder.c_str();
 	string		s_bp(folder.c_str());
 	string		s_pat(pattern);
-	s_pat += "$";
+                //match from beginning of string - stops preg* images from being sorted into normal image groups
+	s_pat = "^" + s_pat + "$"; 
 	
 	/*
 	*	we'll need to match regular expressions against the file name
@@ -111,7 +112,7 @@ void FileList::add(const char *pattern)
 	*	now make a regex
 	*/
 	regex_t r;
-	regcomp(&r, s_pat.c_str(), REG_NOSUB);
+	regcomp(&r, s_pat.c_str(), REG_NOSUB|REG_ICASE); //ignoring case so images work properly
 	
 	/*
 	*	open the directory. Print an error to the console if it fails

--- a/ crazys-wm-mod/cGangs.h
+++ b/ crazys-wm-mod/cGangs.h
@@ -77,15 +77,15 @@ typedef struct sGang
 	void AdjustGangSkill(int skill, int amount);
 	void AdjustGangStat(int stat, int amount);
 
-	int magic(int amount)			{ AdjustGangSkill(SKILL_MAGIC, amount); }
-	int combat(int amount)			{ AdjustGangSkill(SKILL_COMBAT, amount); }
-	int service(int amount)			{ AdjustGangSkill(SKILL_SERVICE, amount); }
-	int intelligence(int amount)	{ AdjustGangStat(STAT_INTELLIGENCE, amount); }
-	int agility(int amount)			{ AdjustGangStat(STAT_AGILITY, amount); }
-	int constitution(int amount)	{ AdjustGangStat(STAT_CONSTITUTION, amount); }
-	int charisma(int amount)		{ AdjustGangStat(STAT_CHARISMA, amount); }
-	int strength(int amount)		{ AdjustGangStat(STAT_STRENGTH, amount); }
-	int happy(int amount)			{ AdjustGangStat(STAT_HAPPINESS, amount); }
+	void magic(int amount)			{ AdjustGangSkill(SKILL_MAGIC, amount); }
+	void combat(int amount)			{ AdjustGangSkill(SKILL_COMBAT, amount); }
+	void service(int amount)			{ AdjustGangSkill(SKILL_SERVICE, amount); }
+	void intelligence(int amount)	{ AdjustGangStat(STAT_INTELLIGENCE, amount); }
+	void agility(int amount)			{ AdjustGangStat(STAT_AGILITY, amount); }
+	void constitution(int amount)	{ AdjustGangStat(STAT_CONSTITUTION, amount); }
+	void charisma(int amount)		{ AdjustGangStat(STAT_CHARISMA, amount); }
+	void strength(int amount)		{ AdjustGangStat(STAT_STRENGTH, amount); }
+	void happy(int amount)			{ AdjustGangStat(STAT_HAPPINESS, amount); }
 
 
 

--- a/ crazys-wm-mod/cRival.cpp
+++ b/ crazys-wm-mod/cRival.cpp
@@ -1079,6 +1079,13 @@ void cRivalManager::CreateRival(long bribeRate, int extort, long gold, int bars,
 		max(0, rival->m_NumBrothels * 5) +
 		max(0, rival->m_NumGamblingHalls * 2) +
 		max(0, rival->m_NumBars * 1));
+        
+                //jim: initializing rival inventory to zero (hopefully fixes Linux segfaults)
+                  rival->m_NumInventory = 0;
+                  for(int i = 0; i <MAXNUM_RIVAL_INVENTORY; i++)
+                  {
+                                    rival->m_Inventory[i] = 0;
+                  }
 
 
 
@@ -1129,6 +1136,13 @@ void cRivalManager::CreateRandomRival()
 	while (rival->m_NumGirls == 0)
 		rival->m_NumGirls = (g_Dice % ((rival->m_NumBrothels) * 20)) + 20;
 	rival->m_NumGangs = g_Dice % 5+3;
+        
+                   //jim: initializing rival inventory to zero (hopefully fixes Linux segfaults)
+                  rival->m_NumInventory = 0;
+                  for(int i = 0; i <MAXNUM_RIVAL_INVENTORY; i++)
+                  {
+                                    rival->m_Inventory[i] = 0;
+                  }
 
 	for (;;) {
 		rival->m_Name = names.random();

--- a/ crazys-wm-mod/cRival.cpp
+++ b/ crazys-wm-mod/cRival.cpp
@@ -1044,6 +1044,13 @@ bool cRivalManager::LoadRivalsXML(TiXmlHandle hRivalManager)
 			// `J` cleanup rival power for .06.01.17
 			if (current->m_Power > 50) current->m_Power = max(0, current->m_NumBrothels * 5) + max(0, current->m_NumGamblingHalls * 2) + max(0, current->m_NumBars * 1);
 
+                                                    //jim: re-initializing rival inventory to zero (hopefully fixes Linux segfaults)
+                                                    current->m_NumInventory = 0;
+                                                    for(int i = 0; i <MAXNUM_RIVAL_INVENTORY; i++)
+                                                    {
+                                                                      current->m_Inventory[i] = 0;
+                                                    }
+                        
 			message = "loaded rival: ";
 			message += current->m_Name;
 			g_LogFile.write(message);

--- a/ crazys-wm-mod/cScreenBuildingManagement.cpp
+++ b/ crazys-wm-mod/cScreenBuildingManagement.cpp
@@ -299,16 +299,16 @@ void cBuildingManagement::set_ids()
 		blocks[i].stealth_up = get_id(string("UpStealth") + istr);
 
 		blocks[i].bevel_t = get_id(
-			string("BevelTop") + istr, false
+			string("BevelTop") + istr, "*Unused*"
 		);
 		blocks[i].bevel_b = get_id(
-			string("BevelBottom") + istr, false
+			string("BevelBottom") + istr, "*Unused*"
 		);
 		blocks[i].bevel_r = get_id(
-			string("BevelRight") + istr, false
+			string("BevelRight") + istr, "*Unused*"
 		);
 		blocks[i].bevel_l = get_id(
-			string("BevelLeft") + istr, false
+			string("BevelLeft") + istr, "*Unused*"
 		);
 		blocks[i].newsplash	= get_id(string("NewSplash") + istr);
 	}

--- a/ crazys-wm-mod/premake4.lua
+++ b/ crazys-wm-mod/premake4.lua
@@ -20,7 +20,9 @@ function main()
 		"*.h",
 		"SDL_anigif.c"
 	})
-
+	
+	excludes({"cMovieScreen.*"})
+	
 	includedirs({
 		"/usr/include/SDL",
 		"/usr/include/lua5.1"


### PR DESCRIPTION
Basic changes to keep the game compiling and running on Linux. Only actual impact on Windows should be a few instruction cycles per rival initialization, unless that gets optimized right out in compiling.